### PR TITLE
Add a new bot for pull events of gitlab.

### DIFF
--- a/example/bots/gitlab_push.js
+++ b/example/bots/gitlab_push.js
@@ -1,0 +1,24 @@
+module.exports = function (chabot) {
+
+   // WebHook で受けたデータをセット
+    var payload = chabot.data;
+ 
+    // ChatWork API の endpoint をセット
+    var endpoint = '/rooms/' + chabot.roomid + '/messages';
+    // templats/ 内のメッセージテンプレートを読み込む
+    var template = chabot.readTemplate('gitlab_push.ejs');
+    // WebHook で受けたデータでメッセージテンプレートを描画
+    var message_body = chabot.render(template, payload);
+
+    // ChatWork API でメッセージ送信
+    chabot.client
+        .post(endpoint, {
+            body: message_body
+        })
+        .done(function (res) {
+            chabot.log('done');
+        })
+        .fail(function (err) {
+            chabot.error(err);
+        });
+};

--- a/example/templates/gitlab_push.ejs
+++ b/example/templates/gitlab_push.ejs
@@ -1,0 +1,8 @@
+[info][title]プッシュのお知らせ♪[/title]
+リポジトリ：<%= repository.name %>
+コミッター：<%= user_name %>
+[hr]<% for(var i=0; i<commits.length; i++) {%>
+   <%= commits[i].message %>
+   <%= commits[i].url %>
+<% } %>
+[/info]


### PR DESCRIPTION
GitLabのPull Events用のbotを追加します。
GitLab 6.7.5 で動作確認しています。

GitLabのWeb Hooksについては以下の参考にしてください。
http://demo.gitlab.com/help/web_hooks
