### PR TITLE
Remove hostname check

### DIFF
--- a/example/config.json
+++ b/example/config.json
@@ -2,7 +2,6 @@
     "port": 5000,
     "bots": {
         "github": {
-            "hostname": "github.com",
             "token": "YOUR_TOKEN",
             "route": "/github/hooks/:roomid"
         }

--- a/lib/bots.js
+++ b/lib/bots.js
@@ -15,12 +15,6 @@ fs.readdirSync(path.join(process.cwd(), 'bots')).forEach(function (botfile) {
             config  = require(cwd + '/config'),
             bot     = require(cwd + '/bots/' + botname);
 
-        if (req.headers.host !== config.bots[botname].hostname) {
-            res.statusCode = 404;
-            res.end();
-            return;
-        }
-
         // chatwork client initialize.
         cw.init({ token: config.bots[botname].token });
 


### PR DESCRIPTION
このホスト名のチェックは不要ではないでしょうか？
サンプルのgithubの設定をみると、webhookの呼び出し元ホストを記載するように見えますが、
実際には呼び出し先のホスト名をチェックしています。
呼び出し先のホスト名はwebhookの種類に関係なく常に一種類なのでチェックする必要は不要かと思います。
